### PR TITLE
0.6.8 for python 3.x and above

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,0 +1,184 @@
+Metadata-Version: 1.0
+Name: innosetup
+Version: 0.6.9
+Summary: distutils extension module - create an installer by InnoSetup.
+Home-page: https://github.com/Surgo/python-innosetup
+Author: chrono-meter@gmx.net
+Author-email: chrono-meter@gmx.net
+License: PSF
+Download-URL: https://github.com/Surgo/python-innosetup/zipball/0.6.9
+Description: ==========================
+        A Python innosetup library
+        ==========================
+        
+        Requirements
+        ------------
+        
+        * Python 2.5 or later
+        * `py2exe <http://pypi.python.org/pypi/py2exe>`_
+        * `pywin32 <http://pypi.python.org/pypi/pywin32>`_
+        * `InnoSetup <http://www.innosetup.com/>`_
+        
+        Features
+        --------
+        
+        * You can use your customized InnoSetup Script.
+        * installer metadata over setup() metadata
+        * generate AppId(GUID) from setup() metadata
+          See the innosetup.InnoScript.appid property.
+        * bundle exe and com dll and dependent libs and resources
+        * bundle msvcr and mfc and their manifest
+        * bundle all installed InnoSetup's language file
+          (If there is no valid [Languages] section.)
+        * create `windows` exe's shortcut
+        * register `com_server` and `service`
+        * check the Windows version with Python version
+        * fix a problem py2exe.mf misses some modules (ex. win32com.shell)
+        
+        Example
+        -------
+        ::
+        
+            from distutils.core import setup
+            import py2exe, innosetup
+        
+            # All options are same as py2exe options.
+            setup(
+                name='example',
+                version='1.0.0.0',
+                license='PSF or other',
+                author='you',
+                author_email='you@your.domain',
+                description='description',
+                url='http://www.your.domain/example', # generate AppId from this url
+                options={
+                    'py2exe': {
+                        # `innosetup` gets the `py2exe`'s options.
+                        'compressed': True,
+                        'optimize': 2,
+                        'bundle_files': 3,
+                        },
+                    'innosetup': {
+                        # user defined iss file path or iss string
+                        'inno_script': innosetup.DEFAULT_ISS, # default is ''
+                        # bundle msvc files
+                        'bundle_vcr': True, # default is True
+                        # zip setup file
+                        'zip': False, # default is False, bool() or zip file name
+                        # create shortcut to startup if you want.
+                        'regist_startup': True, # default is False
+                        }
+                    },
+                com_server=[
+                    {'modules': ['your_com_server_module'], 'create_exe': False},
+                    ],
+                # and other metadata ...
+                )
+        
+        Do the command ``setup.py innosetup``.
+        Then you get InnoSetup script file named ``dist\distutils.iss`` and
+        the installation file named ``dist\<name>-<version>.exe``.
+        
+        
+        Changes
+        -------
+        
+        0.6.8
+        ^^^^^
+        
+        * fix a 'MinVersion' bug.
+        
+        0.6.6, 0.6.7
+        ^^^^^^^^^^^^
+        
+        * update readme and setup script.
+        
+        0.6.5
+        ^^^^^
+        
+        * move download url to github.
+        
+        0.6.4
+        ^^^^^
+        
+        * move repository to github.
+        * add a setup.py script.
+        
+        0.6.3
+        ^^^^^
+        
+        * change versioning policy (remove build number).
+        * add utf-8 bom to .iss file by Jerome Ortais, thanx.
+        * pick up `COPYING` file for `[setup]/LicenseFile` by Jerome Ortais, thanx.
+        
+        0.6.0.2
+        ^^^^^^^
+        
+        * add `regist_startup` option for create shortcut to startup.
+        
+        0.6.0.1
+        ^^^^^^^
+        
+        * fix metadata and unicode by surgo, thanx.
+        * set `DEFAULT_ISS` to empty because `Inno Setup 5.3.9` is released.
+        * fix a problem that `py2exe` includes MinWin's ApiSet Stub DLLs on Windows 7.
+        
+        0.6.0.0
+        ^^^^^^^
+        
+        * support bundling tcl files
+        * change OutputBaseFilename
+        
+        0.5.0.1
+        ^^^^^^^
+        
+        * improve update install support
+        
+        0.5.0.0
+        ^^^^^^^
+        
+        * add DEFAULT_ISS, manifest, srcname, srcnames
+        * add `zip` option
+        * fix `bundle_files=1` option problem (always bundle pythonXX.dll)
+        * add `DefaultGroupName`, `InfoBeforeFile`, `LicenseFile` into `[Setup]`
+          section
+        
+        0.4.0.0
+        ^^^^^^^
+        
+        * support service cmdline_style options
+        * rewrite codes around iss file
+        
+        0.3.0.0
+        ^^^^^^^
+        
+        * improve the InnoSetup instllation path detection
+        * add `inno_setup_exe` option
+        
+        0.2.0.0
+        ^^^^^^^
+        
+        * handle `py2exe`'s command options
+        * add `bundle_vcr` option
+        
+        0.1.0.0
+        ^^^^^^^
+        
+        * first release
+        
+Keywords: distutils
+Platform: UNKNOWN
+Classifier: Development Status :: 5 - Production/Stable
+Classifier: Environment :: Console
+Classifier: Environment :: Win32 (MS Windows)
+Classifier: Intended Audience :: Developers
+Classifier: License :: OSI Approved :: Python Software Foundation License
+Classifier: Operating System :: Microsoft :: Windows :: Windows NT/2000
+Classifier: Operating System :: Microsoft :: Windows :: Windows XP
+Classifier: Operating System :: Microsoft :: Windows :: Windows 7
+Classifier: Programming Language :: Python :: 2 :: Only
+Classifier: Programming Language :: Python :: 2.5
+Classifier: Programming Language :: Python :: 2.6
+Classifier: Programming Language :: Python :: 2.7
+Classifier: Topic :: Software Development :: Build Tools
+Classifier: Topic :: Software Development :: Libraries :: Python Modules

--- a/innosetup/__init__.py
+++ b/innosetup/__init__.py
@@ -9,7 +9,7 @@ __version__ = '0.6.9'
 import sys
 
 import distutils.command
-from innosetup import (innosetup, DEFAULT_ISS, DEFAULT_CODES)
+from .innosetup import (innosetup, DEFAULT_ISS, DEFAULT_CODES)
 
 
 distutils.command.__all__.append('innosetup')

--- a/innosetup/innosetup.py
+++ b/innosetup/innosetup.py
@@ -9,7 +9,7 @@ import subprocess
 import ctypes
 import codecs
 import uuid
-import _winreg
+import winreg
 import distutils.msvccompiler
 from modulefinder import packagePathMap
 from zipfile import (ZipFile, ZIP_DEFLATED)
@@ -151,13 +151,13 @@ def findfiles(filenames, *conditions):
 
 
 hkshortnames = {
-    'HKLM': _winreg.HKEY_LOCAL_MACHINE,
-    'HKCU': _winreg.HKEY_CURRENT_USER,
-    'HKCR': _winreg.HKEY_CLASSES_ROOT,
-    'HKU': _winreg.HKEY_USERS,
-    'HKCC': _winreg.HKEY_CURRENT_CONFIG,
-    'HKDD': _winreg.HKEY_DYN_DATA,
-    'HKPD': _winreg.HKEY_PERFORMANCE_DATA,
+    'HKLM': winreg.HKEY_LOCAL_MACHINE,
+    'HKCU': winreg.HKEY_CURRENT_USER,
+    'HKCR': winreg.HKEY_CLASSES_ROOT,
+    'HKU': winreg.HKEY_USERS,
+    'HKCC': winreg.HKEY_CURRENT_CONFIG,
+    'HKDD': winreg.HKEY_DYN_DATA,
+    'HKPD': winreg.HKEY_PERFORMANCE_DATA,
 }
 
 
@@ -178,14 +178,14 @@ def getregvalue(path, default=None):
     elif root in hkshortnames:
         root = hkshortnames[root]
     else:
-        root = _winreg.HKEY_CURRENT_USER
+        root = winreg.HKEY_CURRENT_USER
         subkey = path
 
     subkey, name = subkey.rsplit('\\', 1)
 
     try:
-        handle = _winreg.OpenKey(root, subkey)
-        value, typeid = _winreg.QueryValueEx(handle, name)
+        handle = winreg.OpenKey(root, subkey)
+        value, typeid = winreg.QueryValueEx(handle, name)
         return value
     except EnvironmentError:
         return default
@@ -197,7 +197,7 @@ class IssFile(file):
 
     def issline(self, **kwargs):
         args = []
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             if k not in self.noescape:
                 # ' -> ''
                 v = '"%s"' % v
@@ -273,7 +273,7 @@ class InnoScript(object):
     @property
     def metadata(self):
         metadata = dict((k, v or '') for k, v in
-                        self.builder.distribution.metadata.__dict__.items())
+                        list(self.builder.distribution.metadata.__dict__.items()))
         return metadata
 
     @property
@@ -293,7 +293,7 @@ class InnoScript(object):
     @property
     def iss_consts(self):
         metadata = self.metadata
-        return dict((k, v % metadata) for k, v in self.consts_map.items())
+        return dict((k, v % metadata) for k, v in list(self.consts_map.items()))
 
     @property
     def innoexepath(self):
@@ -375,7 +375,7 @@ class InnoScript(object):
     def handle_iss_setup(self, lines, fp):
         metadata = self.metadata
         iss_metadata = dict((k, v % metadata)
-                            for k, v in self.metadata_map.items())
+                            for k, v in list(self.metadata_map.items()))
         iss_metadata['OutputDir'] = self.builder.dist_dir
         iss_metadata['AppId'] = self.appid
 
@@ -413,9 +413,9 @@ class InnoScript(object):
                 fp.write(line + '\n')
 
         if 'AppId' in iss_metadata:
-            print('There is no "AppId" in "[Setup]" section.\n'
+            print(('There is no "AppId" in "[Setup]" section.\n'
             '"AppId" is automatically generated from metadata (%s),'
-            'not a random value.' % iss_metadata['AppId'])
+            'not a random value.' % iss_metadata['AppId']))
 
         for k in sorted(iss_metadata):
             fp.write(('%s=%s\n' % (k, iss_metadata[k], )).encode('utf_8'))
@@ -660,7 +660,7 @@ class InnoScript(object):
             'PYTHON_DIR': sys.prefix,
             'PYTHON_DLL': modname(sys.dllhandle),
             })
-        consts.update((k.upper(), v) for k, v in self.metadata.items())
+        consts.update((k.upper(), v) for k, v in list(self.metadata.items()))
         for k in sorted(consts):
             fp.write(('#define %s "%s"\n' % (k, consts[k], )).encode('utf_8'))
 
@@ -694,7 +694,7 @@ class InnoScript(object):
 
         # zip the setup file
         if self.builder.zip:
-            if isinstance(self.builder.zip, basestring):
+            if isinstance(self.builder.zip, str):
                 zipname = self.builder.zip
             else:
                 zipname = setupfile + '.zip'

--- a/innosetup/innosetup.py
+++ b/innosetup/innosetup.py
@@ -755,9 +755,9 @@ class innosetup(py2exe):
         py2exe.run(self)
 
         script = InnoScript(self)
-        print "*** creating the inno setup script ***"
+        #print "*** creating the inno setup script ***"
         script.create()
-        print "*** compiling the inno setup script ***"
+        #print "*** compiling the inno setup script ***"
         script.compile()
 
 


### PR DESCRIPTION
Innosetup causes errors with Python 3.x and above. Have changed all the syntax and import module to 3.x specific.
